### PR TITLE
Dm 17/mensaje acorde ante datos incorrectos registrase

### DIFF
--- a/src/components/auth/signupForm/SignupForm.tsx
+++ b/src/components/auth/signupForm/SignupForm.tsx
@@ -2,30 +2,10 @@
 import TextInput from "@/components/common/TextInput";
 import {Controller, useForm} from "react-hook-form";
 import {yupResolver} from "@hookform/resolvers/yup";
-import * as yup from "yup";
 import {useRouter} from "next/navigation";
-import { postSignup } from "@/services/signup";
-
-const shema = yup
-	.object({
-		firstname: yup
-			.string()
-			.required("El campo es requerido")
-			.matches(/^(?! )[A-Za-z\s]+$/, "El campo solo puede contener letras"),
-			lastname: yup
-			.string()
-			.required("El campo es requerido")
-			.matches(/^(?! )[A-Za-z\s]+$/, "El campo solo puede contener letras"),
-		dni: yup.number().positive().integer().required("El campo es requerido"),
-		email: yup.string().required("El campo es requerido").matches(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "Correo inválido"),
-		password: yup.string().required("El campo es requerido").matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[$@$!%*?&])[A-Za-z\d$@$!%*?&]{6,20}$/, "Contraseña inválida"),
-		confirmPassword: yup
-			.string()
-			.required("El campo es requerido")
-			.oneOf([yup.ref("password")], "Las contraseñas no coinciden"),
-		phone: yup.string().required("El campo es requerido"),
-	})
-	.required();
+import {postSignup} from "@/services/signup";
+import {shema} from "@/schema";
+import {SignupData} from "@/interfaces/signup";
 
 export default function SignupForm() {
 	const router = useRouter();
@@ -39,7 +19,7 @@ export default function SignupForm() {
 		defaultValues: {
 			firstname: "",
 			lastname: "",
-			dni: undefined,
+			dni: "",
 			email: "",
 			password: "",
 			confirmPassword: "",
@@ -47,18 +27,22 @@ export default function SignupForm() {
 		},
 	});
 
-	const onSubmit = async (data: any) => {
-		const resp = await postSignup(data);
-		console.log(resp);
+	const onSubmit = async (data: SignupData) => {
+		const {dni} = data;
 
-		// Limpiamos los campos
+		const body = {
+			...data,
+			dni: Number(dni),
+		};
+
+		const resp = await postSignup(body);
+
 		reset();
 
 		if (resp) {
 			// Si el registro es exitoso, redirigimos al usuario a la pagina de registro exitoso
 			router.push("/signup/success");
 		}
-		
 	};
 
 	return (
@@ -107,9 +91,8 @@ export default function SignupForm() {
 								<TextInput
 									{...field}
 									id="dni"
-									type="number"
+									type="text"
 									placeholder="DNI*"
-									defaultValue={""}
 									errorText={errors.dni?.message}
 								/>
 							)}

--- a/src/interfaces/signup.ts
+++ b/src/interfaces/signup.ts
@@ -1,0 +1,25 @@
+export interface SignupData {
+	dni: string,
+  email: string,
+  firstname: string,
+  lastname: string,
+  password: string,
+  confirmPassword: string,
+  phone: string,
+}
+
+export interface PostSignupBody {
+	dni: number,
+  email: string,
+  firstname: string,
+  lastname: string,
+  password: string,
+  confirmPassword: string,
+  phone: string,
+}
+
+export interface PostSignupResponse {
+	account_id: number;
+	email: string;
+	user_id: number;
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,0 +1,1 @@
+export * from "./signup";

--- a/src/schema/signup.ts
+++ b/src/schema/signup.ts
@@ -1,0 +1,36 @@
+import * as yup from "yup";
+
+export const shema = yup
+	.object({
+		firstname: yup
+			.string()
+      .required("El campo es requerido")
+      .min(3, "El campo debe tener al menos 3 caracteres")
+			.matches(/^(?! )[A-Za-z\s]+$/, "El campo solo puede contener letras"),
+		lastname: yup
+			.string()
+      .required("El campo es requerido")
+      .min(3, "El campo debe tener al menos 3 caracteres")
+			.matches(/^(?! )[A-Za-z\s]+$/, "El campo solo puede contener letras"),
+    dni: yup
+      .string()
+      .required("El campo es requerido")
+      .matches(/^[0-9]{8}$/, "DNI inválido"),
+		email: yup
+			.string()
+			.required("El campo es requerido")
+			.matches(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, "Correo inválido"),
+		password: yup
+			.string()
+			.required("El campo es requerido")
+			.matches(
+				/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[$@$!%*?&])[A-Za-z\d$@$!%*?&]{6,20}$/,
+				"Contraseña inválida"
+			),
+		confirmPassword: yup
+			.string()
+			.required("El campo es requerido")
+			.oneOf([yup.ref("password")], "Las contraseñas no coinciden"),
+		phone: yup.string().required("El campo es requerido"),
+	})
+	.required();

--- a/src/services/signup.ts
+++ b/src/services/signup.ts
@@ -1,20 +1,5 @@
+import {PostSignupBody, PostSignupResponse} from "@/interfaces/signup";
 import {httpPost} from "./common/http";
-
-interface PostSignupBody {
-	dni: number,
-  email: string,
-  firstname: string,
-  lastname: string,
-  password: string,
-  confirmPassword: string,
-  phone: string,
-}
-
-interface PostSignupResponse {
-	account_id: number;
-	email: string;
-	user_id: number;
-}
 
 export async function postSignup(
 	body: PostSignupBody,


### PR DESCRIPTION
[DM-17] Mensajes de Validación al Registrarse

Se han agregado mensajes de validación específicos al formulario de registro para mejorar la experiencia del usuario al proporcionar datos incorrectos. Estas validaciones aseguran que los datos ingresados sean correctos y completos antes de enviar el formulario.

Tarea de Jira:
DM-17: [Front] Mensaje acorde ante datos incorrectos (Al registrarse)

Detalles Técnicos:
Archivo modificado: schema/signup.ts
Librería utilizada: yup para la validación de formularios.
Se agregaron las siguientes validaciones al esquema de Yup:
firstname: Campo requerido, mínimo 3 caracteres, solo letras.
lastname: Campo requerido, mínimo 3 caracteres, solo letras.
dni: Campo requerido, exactamente 8 dígitos numéricos.
email: Campo requerido, formato de correo válido.
password: Campo requerido, entre 6 y 20 caracteres, al menos una letra mayúscula, una minúscula, un número y un carácter especial.
confirmPassword: Campo requerido, debe coincidir con el campo password.
phone: Campo requerido.

![image](https://github.com/user-attachments/assets/2ed33c2d-cb62-4dee-9e24-c7384618bed4)

Pruebas:
Se realizaron pruebas manuales en el formulario de registro para asegurar que las validaciones funcionen correctamente en todos los escenarios posibles. Se verificaron los siguientes casos:

Campos vacíos.
Longitud mínima y formato incorrecto.
Coincidencia de contraseñas.
Impacto:
Con estos cambios, se mejora la validación del formulario de registro, lo que resulta en una mejor experiencia de usuario y en la prevención de errores al ingresar datos incorrectos.


