### PR TITLE
Eliminación del token de la cookie al cerrar sesión

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -9,8 +9,8 @@ export default function DashboardLayout({
  children: React.ReactNode;
 }) {
   return (
-    <div>
+    <main className="">
       {children}
-    </div>
+    </main>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,27 @@
+"use client";
+import Header from "@/components/layout/header/Header";
+import {removeCookieAuth} from "@/utils/cookie";
+import {useRouter} from "next/navigation";
 
 export default function DashboardPage() {
-  return (
-    <div>
-      <h1>
-        Dashboard Page
-      </h1>
-    </div>
-  );
+	const router = useRouter();
+
+	// TODO: esto se debe pasar a al componente que va a manejar el cierra de sesión
+	const handleLogout = () => {
+		removeCookieAuth("authToken");
+		router.push("/");
+	};
+
+	return (
+		<>
+			<Header
+				logoLink="/"
+				headerClassName="bg-primary"
+				logoClassName="fill-black"
+			/>
+			<div>
+				<button onClick={handleLogout}>Cerrar sesión</button>
+			</div>
+		</>
+	);
 }


### PR DESCRIPTION
Este PR introduce la funcionalidad de cierre de sesión en la aplicación, eliminando de forma segura el token de autenticación (authToken) almacenado en las cookies cuando el usuario decide cerrar sesión.

Cambios realizados:

1. Funcionalidad de cierre de sesión:

- Se implementó un botón de "Cerrar sesión" en la página de Dashboard que, al ser clicado, llama a la función removeCookieAuth para eliminar la cookie de autenticación (authToken).
- Después de eliminar la cookie, el usuario es redirigido a la página de inicio (/) utilizando router.push().

2. Justificación:

- Seguridad:

Al eliminar el token de autenticación del almacenamiento, se asegura que la sesión del usuario se cierre completamente, protegiendo la información sensible y previniendo accesos no autorizados.

- Mejora en la experiencia del usuario:

La adición de una funcionalidad clara y efectiva para cerrar sesión mejora la experiencia del usuario al darle control sobre su sesión en la aplicación.

3. Pruebas realizadas:

- Se verificó que al hacer clic en "Cerrar sesión", el token de autenticación se elimina correctamente de las cookies.
- Se comprobó que, una vez cerrada la sesión, cualquier intento de acceder a rutas protegidas como /dashboard redirige al usuario a la página de inicio.
- Se validó que el usuario es redirigido a la página de inicio inmediatamente después de cerrar sesión.